### PR TITLE
Allow `pil {` in pil block definitions

### DIFF
--- a/src/parser/powdr.lalrpop
+++ b/src/parser/powdr.lalrpop
@@ -195,7 +195,7 @@ InstructionParam: InstructionParam = {
 }
 
 InlinePil: ASMStatement = {
-    <@L> "pil{" <(<Statement> ";")*> "}" => ASMStatement::InlinePil(<>)
+    <@L> "pil" "{" <(<Statement> ";")*> "}" => ASMStatement::InlinePil(<>)
 }
 
 Assignment: ASMStatement = {


### PR DESCRIPTION
Now only `pil{` (without space) is allowed.