### PR TITLE
Avoid cloning witness cols for each row

### DIFF
--- a/src/witness_generator/mod.rs
+++ b/src/witness_generator/mod.rs
@@ -127,6 +127,10 @@ impl<'a> FixedData<'a> {
             witness_ids,
         }
     }
+
+    fn witness_cols(&self) -> impl Iterator<Item = &WitnessColumn> {
+        self.witness_cols.iter()
+    }
 }
 
 impl<'a> WitnessColumnNamer for FixedData<'a> {


### PR DESCRIPTION
A lot of times borrow checker issues stem from things being implemented on a struct rather than on its members. Doing the latter helps the borrow checker because it needs references to the members, not to the whole struct, which makes the references less likely to clash.