### PR TITLE
Add a mini runtime to remove loop{} at the end of the main function

### DIFF
--- a/runtime/.cargo/config
+++ b/runtime/.cargo/config
@@ -1,0 +1,5 @@
+[target.riscv32imc-unknown-none-elf]
+rustflags = ["-C", "link-arg=-Tlink.x", "-C", "opt-level=3"]
+
+[build]
+target = "riscv32imc-unknown-none-elf"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "runtime"
+version = "0.1.0"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/runtime/build.rs
+++ b/runtime/build.rs
@@ -1,0 +1,14 @@
+use std::{env, error::Error, fs::File, io::Write, path::PathBuf};
+
+fn main() -> Result<(), Box<dyn Error>> {
+    // build directory for this crate
+    let out_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());
+
+    // extend the library search path
+    println!("cargo:rustc-link-search={}", out_dir.display());
+
+    // put `link.x` in the build directory
+    File::create(out_dir.join("link.x"))?.write_all(include_bytes!("link.x"))?;
+
+    Ok(())
+}

--- a/runtime/link.x
+++ b/runtime/link.x
@@ -1,0 +1,27 @@
+/* Memory layout is assumed to be 1GB of RAM */
+MEMORY
+{
+  RAM : ORIGIN = 0x00000000, LENGTH = 1024M
+}
+
+/* The entry point is the reset handler */
+ENTRY(start);
+
+SECTIONS
+{
+  .start ORIGIN(RAM) :
+  {
+    KEEP(*(.start));  
+  } > RAM
+
+  .text :
+  {
+    *(.text .text.* .eh_*);
+  } > RAM
+
+  /* TODO : discard all extra sections */
+  /DISCARD/ :
+  {
+    *(.ARM.exidx .ARM.exidx.*);
+  }
+}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1,0 +1,28 @@
+#![no_std]
+
+use core::arch::asm;
+use core::panic::PanicInfo;
+
+#[panic_handler]
+fn panic(_panic: &PanicInfo<'_>) -> ! {
+    loop {}
+}
+
+#[link_section = ".start"]
+#[no_mangle]
+pub unsafe extern "C" fn start() -> ! {
+    extern "Rust" {
+        fn main() -> ();
+    }
+    main();
+    loop {}
+}
+
+#[inline]
+pub fn get_prover_input(index: u32) -> u32 {
+    let mut value: u32;
+    unsafe {
+        asm!("ecall", lateout("a0") value, in("a0") index);
+    }
+    value
+}

--- a/tests/riscv_data/sum/.cargo/config
+++ b/tests/riscv_data/sum/.cargo/config
@@ -1,0 +1,5 @@
+[target.riscv32imc-unknown-none-elf]
+rustflags = ["-C", "link-arg=-Tlink.x", "-C", "opt-level=3"]
+
+[build]
+target = "riscv32imc-unknown-none-elf"

--- a/tests/riscv_data/sum/Cargo.toml
+++ b/tests/riscv_data/sum/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "sum"
+version = "0.1.0"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+runtime = { path = "../../../runtime" }

--- a/tests/riscv_data/sum/src/main.rs
+++ b/tests/riscv_data/sum/src/main.rs
@@ -1,0 +1,18 @@
+#![no_std]
+#![no_main]
+
+extern crate runtime;
+use runtime::get_prover_input;
+
+#[no_mangle]
+pub fn main() -> () {
+    let mut buffer = [0u32; 100];
+    let proposed_sum = get_prover_input(0);
+    let len = get_prover_input(1) as usize;
+    assert!(len > 0 && len < 100);
+    for i in 0..len {
+        buffer[i] = get_prover_input(2 + i as u32);
+    }
+    let sum: u32 = buffer[..len].iter().sum();
+    assert!(sum == proposed_sum);
+}


### PR DESCRIPTION
This PR follows a discussion with Leo and Thibaut, to create a mini runtime so that users do not have to add `loop {}` at the end of their functions.

**NOTE** the PR is still in draft and the example will not compile to PIL. I am seeking feedback to make sure this effort is worth pursuing.

### High-level overview of the changes

 - Creates a `runtime` crate that contains the `loop {}` and calls the `main` function of any crate using this runtime crate as a dependency
 - The `sum` example is moved to its own crate, with a dependency on the 
 - The  function to read inputs is moved to the runtime
 - App users need to add `#[no_main]` at the top of their crate

### Low-level description of the changes

riscv code generation is now done with cargo. A `start` function is provided in the runtime, that will first call the user crate's `main` function and then loop indefinitely. A linker script is provided for the compiler to put the runtime's `start` function at the beginning of the code, to call the user crate's `main` function and then loop indefinitely when `main` returns. The `start` function is forced at the start of the code section by putting it into a special `.start` section that is placed at the beginning. Because the linker script needs a size for the memory area, I set it to be 1GB, which should be enough, but I could also set it to be 4GB (i.e. a 32 bit address space) if it makes more sense. 

### What still has to be done

 - [ ] asm export, it's currently emitting an object file 
 - [ ] Change the call to `rust` so that the asm is produced
 - [ ] update README to reflect UX changes
 - [ ] strip debug symbols and other unnecessary sections from the output binary