### PR TITLE
Use ark_ff under the hood

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 build = "build.rs"
 
 [dependencies]
+ark-ff = "0.4.2"
 clap = { version = "^4.1", features = ["derive"] }
 codespan-reporting = "^0.11"
 env_logger = "0.10.0"
@@ -14,7 +15,6 @@ lalrpop-util = {version = "^0.19", features = ["lexer"]}
 lazy_static = "^1.4.0"
 log = "0.4.17"
 mktemp = "0.5.0"
-num-bigint = "^0.4"
 regex = "^1.7.0"
 walkdir = "2.3.3"
 

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -4,7 +4,7 @@ pub mod pil_analyzer;
 use std::collections::HashMap;
 use std::path::Path;
 
-use crate::number::{AbstractNumberType, DegreeType};
+use crate::number::{DegreeType, FieldElement};
 pub use crate::parser::ast::{BinaryOperator, UnaryOperator};
 
 pub fn analyze(path: &Path) -> Analyzed {
@@ -23,7 +23,7 @@ pub enum StatementIdentifier {
 
 pub struct Analyzed {
     /// Constants are not namespaced!
-    pub constants: HashMap<String, AbstractNumberType>,
+    pub constants: HashMap<String, FieldElement>,
     pub definitions: HashMap<String, (Polynomial, Option<FunctionValueDefinition>)>,
     pub public_declarations: HashMap<String, PublicDeclaration>,
     pub identities: Vec<Identity>,
@@ -152,17 +152,14 @@ pub enum Expression {
     PolynomialReference(PolynomialReference),
     LocalVariableReference(u64),
     PublicReference(String),
-    Number(AbstractNumberType),
+    Number(FieldElement),
     String(String),
     Tuple(Vec<Expression>),
     BinaryOperation(Box<Expression>, BinaryOperator, Box<Expression>),
     UnaryOperation(UnaryOperator, Box<Expression>),
     /// Call to a non-macro function (like a constant polynomial)
     FunctionCall(String, Vec<Expression>),
-    MatchExpression(
-        Box<Expression>,
-        Vec<(Option<AbstractNumberType>, Expression)>,
-    ),
+    MatchExpression(Box<Expression>, Vec<(Option<FieldElement>, Expression)>),
 }
 
 #[derive(Debug, PartialEq, Eq, Default, Clone)]

--- a/src/bin/compiler.rs
+++ b/src/bin/compiler.rs
@@ -2,7 +2,7 @@ use clap::{Parser, Subcommand};
 use env_logger::{Builder, Target};
 use log::LevelFilter;
 use powdr::compiler::no_callback;
-use powdr::number::AbstractNumberType;
+use powdr::number::FieldElement;
 use std::{fs, io::Write, path::Path};
 
 #[derive(Parser)]
@@ -102,13 +102,13 @@ enum Commands {
     },
 }
 
-fn split_inputs(inputs: &str) -> Vec<AbstractNumberType> {
+fn split_inputs(inputs: &str) -> Vec<FieldElement> {
     inputs
         .split(',')
         .map(|x| x.trim())
         .filter(|x| !x.is_empty())
-        .map(|x| x.parse().unwrap())
-        .collect::<Vec<AbstractNumberType>>()
+        .map(|x| x.parse::<u64>().unwrap().into())
+        .collect::<Vec<FieldElement>>()
 }
 
 fn main() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,3 @@
-#[macro_use]
-extern crate lazy_static;
-
 pub mod analyzer;
 pub mod asm_compiler;
 pub mod compiler;

--- a/src/number.rs
+++ b/src/number.rs
@@ -1,47 +1,262 @@
-use num_bigint::{BigInt, Sign};
-use std::sync::Mutex;
+use std::{fmt, ops::AddAssign};
+
+use ark_ff::{
+    fields::{Field, Fp64, MontBackend, MontConfig},
+    BigInteger, PrimeField, Zero,
+};
+
+#[derive(MontConfig)]
+#[modulus = "18446744069414584321"]
+#[generator = "7"]
+pub struct GoldilocksBaseFieldConfig;
+pub type GoldilocksBaseField = Fp64<MontBackend<GoldilocksBaseFieldConfig, 1>>;
 
 /// The abstract type of numbers to be computed with.
-/// They have arbitrary precision, but need to be converted
-/// to a finite field element once we generate the column values.
-pub type AbstractNumberType = num_bigint::BigInt;
+/// TODO: use arbitrary precision
+pub type AbstractNumberType = u128;
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Default, PartialOrd, Ord, Hash)]
+pub struct FieldElement {
+    value: GoldilocksBaseField,
+}
 /// The type of polynomial degrees and indices into columns.
 pub type DegreeType = u64;
 
-pub fn abstract_to_degree(input: &AbstractNumberType) -> DegreeType {
-    match input.to_biguint().unwrap().to_u64_digits()[..] {
-        [] => 0,
-        [d] => d,
-        _ => panic!(),
+impl FieldElement {
+    pub fn to_degree(&self) -> DegreeType {
+        self.to_integer() as DegreeType
+    }
+
+    pub fn to_integer(&self) -> AbstractNumberType {
+        let value_big = self.value.into_bigint();
+        assert_eq!(value_big.0.len(), 1);
+        value_big.0[0] as AbstractNumberType
+    }
+
+    pub fn modulus() -> AbstractNumberType {
+        GoldilocksBaseField::MODULUS.0[0] as AbstractNumberType
+    }
+
+    pub fn zero() -> Self {
+        Self::from(0)
+    }
+
+    pub fn is_zero(&self) -> bool {
+        self.value.is_zero()
+    }
+
+    pub fn pow(self, exponent: AbstractNumberType) -> Self {
+        Self {
+            value: self.value.pow([exponent as u64]),
+        }
+    }
+
+    pub fn integer_div(self, other: Self) -> Self {
+        (self.to_integer() / other.to_integer()).into()
+    }
+
+    pub fn to_bytes_le(&self) -> Vec<u8> {
+        self.value.into_bigint().to_bytes_le()
     }
 }
 
-pub fn is_zero(x: &AbstractNumberType) -> bool {
-    x.sign() == Sign::NoSign
+impl<V: Into<GoldilocksBaseField>> From<V> for FieldElement {
+    fn from(value: V) -> Self {
+        Self {
+            value: value.into(),
+        }
+    }
 }
 
-lazy_static! {
-    // default field modulus is goldilocks
-    static ref GOLDILOCKS_MOD : BigInt = BigInt::parse_bytes(b"FFFFFFFF00000001", 16).unwrap();
-    static ref FIELD_MOD : Mutex<BigInt> = Mutex::new(BigInt::parse_bytes(b"FFFFFFFF00000001", 16).unwrap());
+// Add
+
+impl std::ops::Add for FieldElement {
+    type Output = FieldElement;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        FieldElement {
+            value: self.value + rhs.value,
+        }
+    }
 }
 
-pub fn get_goldilocks_mod() -> BigInt {
-    GOLDILOCKS_MOD.clone()
+impl<'a> std::ops::Add<&'a FieldElement> for FieldElement {
+    type Output = FieldElement;
+
+    fn add(self, rhs: &'a FieldElement) -> Self::Output {
+        FieldElement {
+            value: self.value + rhs.value,
+        }
+    }
 }
 
-pub fn get_field_mod() -> BigInt {
-    FIELD_MOD.lock().unwrap().clone()
+impl<'a> std::ops::Add for &'a FieldElement {
+    type Output = FieldElement;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        FieldElement {
+            value: self.value + rhs.value,
+        }
+    }
 }
 
-pub fn set_field_mod(n: BigInt) {
-    *FIELD_MOD.lock().unwrap() = n;
+impl<'a> std::ops::Add<FieldElement> for &'a FieldElement {
+    type Output = FieldElement;
+
+    fn add(self, rhs: FieldElement) -> Self::Output {
+        FieldElement {
+            value: self.value + rhs.value,
+        }
+    }
 }
 
-pub fn format_number(x: &AbstractNumberType) -> String {
-    if *x > (get_field_mod() / BigInt::from(2)) {
-        format!("-{}", get_field_mod() - x)
-    } else {
-        format!("{x}")
+impl AddAssign for FieldElement {
+    fn add_assign(&mut self, rhs: Self) {
+        self.value.add_assign(rhs.value);
+    }
+}
+
+// Sub
+
+impl std::ops::Sub for FieldElement {
+    type Output = FieldElement;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        FieldElement {
+            value: self.value - rhs.value,
+        }
+    }
+}
+
+impl<'a> std::ops::Sub<&'a FieldElement> for FieldElement {
+    type Output = FieldElement;
+
+    fn sub(self, rhs: &'a FieldElement) -> Self::Output {
+        FieldElement {
+            value: self.value - rhs.value,
+        }
+    }
+}
+
+impl<'a> std::ops::Sub for &'a FieldElement {
+    type Output = FieldElement;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        FieldElement {
+            value: self.value - rhs.value,
+        }
+    }
+}
+
+impl<'a> std::ops::Sub<FieldElement> for &'a FieldElement {
+    type Output = FieldElement;
+
+    fn sub(self, rhs: FieldElement) -> Self::Output {
+        FieldElement {
+            value: self.value - rhs.value,
+        }
+    }
+}
+
+// Mul
+
+impl std::ops::Mul for FieldElement {
+    type Output = FieldElement;
+
+    fn mul(self, rhs: Self) -> Self::Output {
+        FieldElement {
+            value: self.value * rhs.value,
+        }
+    }
+}
+
+impl<'a> std::ops::Mul<&'a FieldElement> for FieldElement {
+    type Output = FieldElement;
+
+    fn mul(self, rhs: &'a FieldElement) -> Self::Output {
+        FieldElement {
+            value: self.value * rhs.value,
+        }
+    }
+}
+
+impl<'a> std::ops::Mul for &'a FieldElement {
+    type Output = FieldElement;
+
+    fn mul(self, rhs: Self) -> Self::Output {
+        FieldElement {
+            value: self.value * rhs.value,
+        }
+    }
+}
+
+impl<'a> std::ops::Mul<FieldElement> for &'a FieldElement {
+    type Output = FieldElement;
+
+    fn mul(self, rhs: FieldElement) -> Self::Output {
+        FieldElement {
+            value: self.value * rhs.value,
+        }
+    }
+}
+
+// Div
+
+impl std::ops::Div for FieldElement {
+    type Output = FieldElement;
+
+    fn div(self, rhs: Self) -> Self::Output {
+        FieldElement {
+            value: self.value / rhs.value,
+        }
+    }
+}
+
+impl<'a> std::ops::Div<&'a FieldElement> for FieldElement {
+    type Output = FieldElement;
+
+    fn div(self, rhs: &'a FieldElement) -> Self::Output {
+        FieldElement {
+            value: self.value / rhs.value,
+        }
+    }
+}
+
+impl<'a> std::ops::Div for &'a FieldElement {
+    type Output = FieldElement;
+
+    fn div(self, rhs: Self) -> Self::Output {
+        FieldElement {
+            value: self.value / rhs.value,
+        }
+    }
+}
+
+impl<'a> std::ops::Div<FieldElement> for &'a FieldElement {
+    type Output = FieldElement;
+
+    fn div(self, rhs: FieldElement) -> Self::Output {
+        FieldElement {
+            value: self.value / rhs.value,
+        }
+    }
+}
+
+impl std::ops::Neg for FieldElement {
+    type Output = FieldElement;
+
+    fn neg(self) -> Self::Output {
+        Self { value: -self.value }
+    }
+}
+
+impl fmt::Display for FieldElement {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let value = self.to_integer();
+        if value > (Self::modulus() - 1) / 2 {
+            write!(f, "-{}", Self::modulus() - value)
+        } else {
+            write!(f, "{value}")
+        }
     }
 }

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -1,4 +1,4 @@
-use crate::number::{AbstractNumberType, DegreeType};
+use crate::number::{DegreeType, FieldElement};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct PILFile(pub Vec<Statement>);
@@ -41,17 +41,14 @@ pub enum Expression {
     Constant(String),
     PolynomialReference(PolynomialReference),
     PublicReference(String),
-    Number(AbstractNumberType),
+    Number(FieldElement),
     String(String),
     Tuple(Vec<Expression>),
     BinaryOperation(Box<Expression>, BinaryOperator, Box<Expression>),
     UnaryOperation(UnaryOperator, Box<Expression>),
     FunctionCall(String, Vec<Expression>),
     FreeInput(Box<Expression>),
-    MatchExpression(
-        Box<Expression>,
-        Vec<(Option<AbstractNumberType>, Expression)>,
-    ),
+    MatchExpression(Box<Expression>, Vec<(Option<FieldElement>, Expression)>),
 }
 
 #[derive(Debug, PartialEq, Eq, Default, Clone)]
@@ -151,8 +148,8 @@ impl ArrayExpression {
     /// find the total length of an array expression as an affine expression: `a + b*x`
     fn len(&self) -> (DegreeType, DegreeType) {
         match self {
-            ArrayExpression::RepeatedValue(e) => (0, e.len() as u64),
-            ArrayExpression::Value(e) => (e.len() as u64, 0),
+            ArrayExpression::RepeatedValue(e) => (0, e.len() as DegreeType),
+            ArrayExpression::Value(e) => (e.len() as DegreeType, 0),
             ArrayExpression::Concat(left, right) => {
                 let (a0, b0) = left.len();
                 let (a1, b1) = right.len();

--- a/src/parser/powdr.lalrpop
+++ b/src/parser/powdr.lalrpop
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 use crate::parser::ast::*;
 use crate::parser::asm_ast::*;
-use crate::number::AbstractNumberType;
+use crate::number::{AbstractNumberType, FieldElement};
 
 grammar;
 
@@ -158,7 +158,7 @@ ASMStatement: ASMStatement = {
 }
 
 Degree: ASMStatement = {
-    <@L> "degree" <Number> ";" => ASMStatement::Degree(<>)
+    <@L> "degree" <Integer> ";" => ASMStatement::Degree(<>)
 }
 
 RegisterDeclaration: ASMStatement = {
@@ -333,7 +333,7 @@ Term: Box<Expression> = {
     ConstantIdentifier => Box::new(Expression::Constant(<>)),
     PolynomialReference => Box::new(Expression::PolynomialReference(<>)),
     PublicReference => Box::new(Expression::PublicReference(<>)),
-    Number => Box::new(Expression::Number(<>)),
+    FieldElement => Box::new(Expression::Number(<>)),
     StringLiteral => Box::new(Expression::String(<>)),
     MatchExpression,
     "(" <head:Expression> "," <tail:ExpressionList> ")" => { let mut list = vec![head]; list.extend(tail); Box::new(Expression::Tuple(list)) },
@@ -360,8 +360,8 @@ MatchExpression: Box<Expression> = {
     "match" <BoxedExpression> "{" <(<MatchArm> ",")*> "}" => Box::new(Expression::MatchExpression(<>))
 }
 
-MatchArm: (Option<AbstractNumberType>, Expression) = {
-    <n:Number> "=>" <e:Expression> => (Some(n), e),
+MatchArm: (Option<FieldElement>, Expression) = {
+    <n:FieldElement> "=>" <e:Expression> => (Some(n), e),
     <n:"_"> "=>" <e:Expression> => (None, e),
 }
 
@@ -382,7 +382,12 @@ ConstantIdentifier: String = {
     r"%[a-zA-Z_][a-zA-Z$_0-9@]*" => <>.to_string(),
 }
 
-Number: AbstractNumberType = {
-    r"[0-9][0-9_]*" => i128::from_str(&<>.replace('_', "")).unwrap().into(),
-    r"0x[0-9A-Fa-f][0-9A-Fa-f_]*" => i128::from_str_radix(&<>[2..].replace('_', ""), 16).unwrap().into(),
+FieldElement: FieldElement = {
+    r"[0-9][0-9_]*" => i128::from_str(&<>.replace('_', "")).unwrap().try_into().unwrap(),
+    r"0x[0-9A-Fa-f][0-9A-Fa-f_]*" => i128::from_str_radix(&<>[2..].replace('_', ""), 16).unwrap().try_into().unwrap(),
+}
+
+Integer: AbstractNumberType = {
+    r"[0-9][0-9_]*" => i128::from_str(&<>.replace('_', "")).unwrap().try_into().unwrap(),
+    r"0x[0-9A-Fa-f][0-9A-Fa-f_]*" => i128::from_str_radix(&<>[2..].replace('_', ""), 16).unwrap().try_into().unwrap(),
 }

--- a/src/riscv/mod.rs
+++ b/src/riscv/mod.rs
@@ -4,7 +4,7 @@ use mktemp::Temp;
 use std::fs;
 use walkdir::WalkDir;
 
-use crate::number::AbstractNumberType;
+use crate::number::FieldElement;
 
 pub mod compiler;
 pub mod parser;
@@ -14,7 +14,7 @@ pub mod parser;
 pub fn compile_rust(
     file_name: &str,
     full_crate: bool,
-    inputs: Vec<AbstractNumberType>,
+    inputs: Vec<FieldElement>,
     output_dir: &Path,
     force_overwrite: bool,
 ) {
@@ -57,7 +57,7 @@ pub fn compile_rust(
 pub fn compile_riscv_asm(
     original_file_name: &str,
     file_name: &str,
-    inputs: Vec<AbstractNumberType>,
+    inputs: Vec<FieldElement>,
     output_dir: &Path,
     force_overwrite: bool,
 ) {

--- a/src/witness_generator/affine_expression.rs
+++ b/src/witness_generator/affine_expression.rs
@@ -1,7 +1,6 @@
-use std::ops::Not;
-
+use crate::number::AbstractNumberType;
 // TODO this should probably rather be a finite field element.
-use crate::number::{format_number, get_field_mod, is_zero, AbstractNumberType};
+use crate::number::FieldElement;
 
 use super::bit_constraints::BitConstraintSet;
 use super::eval_error::EvalError::ConflictingBitConstraints;
@@ -13,15 +12,15 @@ use super::EvalResult;
 /// An expression affine in the committed polynomials.
 #[derive(Debug, Clone)]
 pub struct AffineExpression {
-    pub coefficients: Vec<AbstractNumberType>,
-    pub offset: AbstractNumberType,
+    pub coefficients: Vec<FieldElement>,
+    pub offset: FieldElement,
 }
 
-impl From<AbstractNumberType> for AffineExpression {
-    fn from(value: AbstractNumberType) -> Self {
+impl From<FieldElement> for AffineExpression {
+    fn from(value: FieldElement) -> Self {
         AffineExpression {
             coefficients: Vec::new(),
-            offset: wrap(value),
+            offset: value,
         }
     }
 }
@@ -30,7 +29,7 @@ impl From<u32> for AffineExpression {
     fn from(value: u32) -> Self {
         AffineExpression {
             coefficients: Vec::new(),
-            offset: wrap(value.into()),
+            offset: value.into(),
         }
     }
 }
@@ -47,9 +46,9 @@ impl AffineExpression {
         self.nonzero_coefficients().next().is_none()
     }
 
-    pub fn constant_value(&self) -> Option<AbstractNumberType> {
+    pub fn constant_value(&self) -> Option<FieldElement> {
         if self.is_constant() {
-            Some(self.offset.clone())
+            Some(self.offset)
         } else {
             None
         }
@@ -60,19 +59,18 @@ impl AffineExpression {
     }
 
     /// @returns an iterator of the nonzero coefficients and their variable IDs (but not the offset).
-    pub fn nonzero_coefficients(&self) -> impl Iterator<Item = (usize, &AbstractNumberType)> {
+    pub fn nonzero_coefficients(&self) -> impl Iterator<Item = (usize, &FieldElement)> {
         self.coefficients
             .iter()
             .enumerate()
-            .filter(|(_, c)| !is_zero(c))
+            .filter(|(_, c)| !c.is_zero())
     }
 
-    pub fn mul(mut self, factor: AbstractNumberType) -> AffineExpression {
-        let fac = wrap(factor);
+    pub fn mul(mut self, factor: FieldElement) -> AffineExpression {
         for f in &mut self.coefficients {
-            *f = wrap(f.clone() * fac.clone());
+            *f = *f * factor;
         }
-        self.offset = wrap(self.offset.clone() * fac);
+        self.offset = self.offset * factor;
         self
     }
 
@@ -89,11 +87,11 @@ impl AffineExpression {
                 Ok(vec![(
                     i,
                     Constraint::Assignment(if *c == 1.into() {
-                        wrap(-self.offset.clone())
-                    } else if *c == (-1).into() || *c == (get_field_mod() - 1u64) {
-                        self.offset.clone()
+                        -self.offset
+                    } else if *c == (-1).into() {
+                        self.offset
                     } else {
-                        wrap(-wrap(self.offset.clone() * inv(c.clone(), get_field_mod())))
+                        -self.offset / *c
                     }),
                 )])
             }
@@ -177,7 +175,7 @@ impl AffineExpression {
         }
         if *solve_for.1 == 1.into() {
             return (-self.clone()).try_transfer_constraints(known_constraints);
-        } else if *solve_for.1 != wrap((-1).into()) {
+        } else if *solve_for.1 != (-1).into() {
             // We could try to divide by this in the future.
             return None;
         }
@@ -190,7 +188,7 @@ impl AffineExpression {
             .map(|(i, coeff)| {
                 known_constraints
                     .bit_constraint(i)
-                    .and_then(|con| con.multiple(coeff.clone()))
+                    .and_then(|con| con.multiple(*coeff))
             });
 
         parts
@@ -219,7 +217,7 @@ impl AffineExpression {
                     known_constraints
                         .bit_constraint(i)
                         .unwrap()
-                        .multiple(coeff.clone()),
+                        .multiple(*coeff),
                 )
             })
             .collect::<Vec<_>>();
@@ -227,25 +225,25 @@ impl AffineExpression {
             return Ok(vec![]);
         }
         // Check if they are mutually exclusive and compute assignments.
-        let mut covered_bits: AbstractNumberType = 0.into();
+        let mut covered_bits: AbstractNumberType = 0;
         let mut assignments = vec![];
-        let mut offset = wrap(-self.offset.clone());
+        let mut offset = (-self.offset).to_integer();
         for (i, coeff, constraint) in parts {
             let constraint = constraint.clone().unwrap();
             let mask = constraint.mask();
-            if mask.clone() & covered_bits.clone() != 0.into() {
+            if mask & covered_bits != 0 {
                 return Ok(vec![]);
             } else {
-                covered_bits |= mask.clone();
+                covered_bits |= mask;
             }
             assignments.push((
                 i,
-                Constraint::Assignment((offset.clone() & mask.clone()) / coeff.clone()),
+                Constraint::Assignment(((offset & mask) / coeff.to_integer()).into()),
             ));
-            offset &= mask.not();
+            offset &= !mask;
         }
 
-        if offset != 0.into() {
+        if offset != 0 {
             // We were not able to cover all of the offset, so this equation cannot be solved.
             Err(ConflictingBitConstraints)
         } else {
@@ -259,47 +257,16 @@ impl AffineExpression {
                 let name = namer.name(i);
                 if *c == 1.into() {
                     name
-                } else if *c == wrap((-1).into()) {
+                } else if *c == (-1).into() {
                     format!("-{name}")
                 } else {
-                    format!("{} * {name}", format_number(c))
+                    format!("{} * {name}", c)
                 }
             })
             .chain(self.constant_value().map(|v| format!("{v}")))
             .collect::<Vec<_>>()
             .join(" + ")
     }
-}
-
-fn wrap(mut x: AbstractNumberType) -> AbstractNumberType {
-    while x < 0.into() {
-        x += get_field_mod()
-    }
-    x % get_field_mod()
-}
-
-fn pow(
-    mut x: AbstractNumberType,
-    mut y: AbstractNumberType,
-    m: AbstractNumberType,
-) -> AbstractNumberType {
-    assert!(y >= 0.into());
-    if y == 0.into() {
-        return 1.into();
-    }
-    let mut r: AbstractNumberType = 1.into();
-    while y >= 2.into() {
-        if y.bit(0) {
-            r = (r * x.clone()) % m.clone();
-        }
-        x = (x.clone() * x) % m.clone();
-        y = y.clone() >> 1;
-    }
-    (r * x) % m
-}
-
-fn inv(x: AbstractNumberType, m: AbstractNumberType) -> AbstractNumberType {
-    pow(x, m.clone() - 2, m)
 }
 
 impl PartialEq for AffineExpression {
@@ -317,11 +284,11 @@ impl std::ops::Add for AffineExpression {
             coefficients.resize(self.coefficients.len(), 0.into());
         }
         for (i, v) in self.coefficients.iter().enumerate() {
-            coefficients[i] = wrap(coefficients[i].clone() + v);
+            coefficients[i] = coefficients[i] + v;
         }
         AffineExpression {
             coefficients,
-            offset: wrap(self.offset + rhs.offset),
+            offset: self.offset + rhs.offset,
         }
     }
 }
@@ -330,10 +297,8 @@ impl std::ops::Neg for AffineExpression {
     type Output = AffineExpression;
 
     fn neg(mut self) -> Self::Output {
-        self.coefficients
-            .iter_mut()
-            .for_each(|v| *v = wrap(-v.clone()));
-        self.offset = wrap(-self.offset);
+        self.coefficients.iter_mut().for_each(|v| *v = -*v);
+        self.offset = -self.offset;
         self
     }
 }
@@ -352,11 +317,11 @@ mod test {
 
     use super::*;
     use crate::{
-        number::{get_goldilocks_mod, AbstractNumberType},
+        number::FieldElement,
         witness_generator::{bit_constraints::BitConstraint, eval_error::EvalError},
     };
 
-    fn convert(input: Vec<i32>) -> Vec<AbstractNumberType> {
+    fn convert(input: Vec<i32>) -> Vec<FieldElement> {
         input.into_iter().map(|x| x.into()).collect()
     }
 
@@ -369,8 +334,12 @@ mod test {
         assert_eq!(
             -a,
             AffineExpression {
-                coefficients: vec![get_field_mod() - 1u64, 0.into(), get_field_mod() - 2u64,],
-                offset: get_field_mod() - 9u64,
+                coefficients: vec![
+                    FieldElement::from(0) - FieldElement::from(1u64),
+                    0.into(),
+                    FieldElement::from(0) - FieldElement::from(2u64),
+                ],
+                offset: FieldElement::from(0) - FieldElement::from(9u64),
             },
         );
     }
@@ -393,26 +362,6 @@ mod test {
             },
         );
         assert_eq!(b.clone() + a.clone(), a + b,);
-    }
-
-    #[test]
-    pub fn mod_arith() {
-        assert_eq!(pow(7.into(), 0.into(), get_goldilocks_mod()), 1.into());
-        assert_eq!(pow(7.into(), 1.into(), get_goldilocks_mod()), 7.into());
-        assert_eq!(pow(7.into(), 0.into(), get_field_mod()), 1.into());
-        assert_eq!(pow(7.into(), 1.into(), get_field_mod()), 7.into());
-        assert_eq!(pow(7.into(), 2.into(), get_field_mod()), (7 * 7).into());
-        assert_eq!(inv(1.into(), get_field_mod()), 1.into());
-
-        if get_field_mod() == get_goldilocks_mod() {
-            let inverse_of_four = 13835058052060938241u64;
-            assert_eq!(inv(4.into(), get_field_mod()), inverse_of_four.into());
-            assert_eq!(
-                (4u128 * inverse_of_four as u128)
-                    % (get_field_mod().iter_u64_digits().next().unwrap() as u128),
-                1
-            );
-        }
     }
 
     struct TestBitConstraints(BTreeMap<usize, BitConstraint>);
@@ -460,7 +409,7 @@ mod test {
             expr.solve_with_bit_constraints(&known_constraints).unwrap(),
             vec![(
                 1,
-                Constraint::BitConstraint(BitConstraint::from_mask(0x1fef.into()))
+                Constraint::BitConstraint(BitConstraint::from_mask(0x1fef))
             )]
         );
 

--- a/src/witness_generator/fixed_evaluator.rs
+++ b/src/witness_generator/fixed_evaluator.rs
@@ -17,7 +17,7 @@ impl<'a> FixedEvaluator<'a> {
 
 impl<'a> SymbolicVariables for FixedEvaluator<'a> {
     fn constant(&self, name: &str) -> Result<AffineExpression, EvalError> {
-        Ok(self.fixed_data.constants[name].clone().into())
+        Ok(self.fixed_data.constants[name].into())
     }
 
     fn value(&self, name: &str, next: bool) -> Result<AffineExpression, EvalError> {
@@ -29,7 +29,7 @@ impl<'a> SymbolicVariables for FixedEvaluator<'a> {
             } else {
                 self.row
             };
-            Ok(col_data[row].clone().into())
+            Ok(col_data[row].into())
         } else {
             Err("Can only access fixed columns in the fixed evaluator."
                 .to_string()

--- a/src/witness_generator/machines/mod.rs
+++ b/src/witness_generator/machines/mod.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use crate::analyzer::{IdentityKind, SelectedExpressions};
-use crate::number::AbstractNumberType;
+use crate::number::FieldElement;
 
 pub use self::fixed_lookup_machine::FixedLookup;
 
@@ -41,8 +41,5 @@ pub trait Machine {
     ) -> Option<EvalResult>;
 
     /// Returns the final values of the witness columns.
-    fn witness_col_values(
-        &mut self,
-        fixed_data: &FixedData,
-    ) -> HashMap<String, Vec<AbstractNumberType>>;
+    fn witness_col_values(&mut self, fixed_data: &FixedData) -> HashMap<String, Vec<FieldElement>>;
 }

--- a/src/witness_generator/mod.rs
+++ b/src/witness_generator/mod.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::fmt::Display;
 
 use crate::analyzer::{Analyzed, Expression, FunctionValueDefinition};
-use crate::number::{AbstractNumberType, DegreeType};
+use crate::number::{DegreeType, FieldElement};
 
 use self::bit_constraints::BitConstraint;
 use self::eval_error::EvalError;
@@ -24,9 +24,9 @@ mod util;
 pub fn generate<'a>(
     analyzed: &'a Analyzed,
     degree: DegreeType,
-    fixed_cols: &[(&str, Vec<AbstractNumberType>)],
-    query_callback: Option<impl FnMut(&str) -> Option<AbstractNumberType>>,
-) -> Vec<(&'a str, Vec<AbstractNumberType>)> {
+    fixed_cols: &[(&str, Vec<FieldElement>)],
+    query_callback: Option<impl FnMut(&str) -> Option<FieldElement>>,
+) -> Vec<(&'a str, Vec<FieldElement>)> {
     let witness_cols: Vec<WitnessColumn> = analyzed
         .committed_polys_in_source_order()
         .iter()
@@ -62,7 +62,7 @@ pub fn generate<'a>(
         query_callback,
     );
 
-    let mut values: Vec<(&str, Vec<AbstractNumberType>)> =
+    let mut values: Vec<(&str, Vec<FieldElement>)> =
         witness_cols.iter().map(|p| (p.name, Vec::new())).collect();
     for row in 0..degree as DegreeType {
         let row_values = generator.compute_next_row(row);
@@ -89,7 +89,7 @@ type EvalResult = Result<Vec<(usize, Constraint)>, EvalError>;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum Constraint {
-    Assignment(AbstractNumberType),
+    Assignment(FieldElement),
     BitConstraint(BitConstraint),
 }
 
@@ -105,8 +105,8 @@ impl Display for Constraint {
 /// Data that is fixed for witness generation.
 pub struct FixedData<'a> {
     degree: DegreeType,
-    constants: &'a HashMap<String, AbstractNumberType>,
-    fixed_cols: HashMap<&'a str, &'a Vec<AbstractNumberType>>,
+    constants: &'a HashMap<String, FieldElement>,
+    fixed_cols: HashMap<&'a str, &'a Vec<FieldElement>>,
     witness_cols: &'a Vec<WitnessColumn<'a>>,
     witness_ids: HashMap<&'a str, usize>,
 }
@@ -114,8 +114,8 @@ pub struct FixedData<'a> {
 impl<'a> FixedData<'a> {
     pub fn new(
         degree: DegreeType,
-        constants: &'a HashMap<String, AbstractNumberType>,
-        fixed_cols: HashMap<&'a str, &'a Vec<AbstractNumberType>>,
+        constants: &'a HashMap<String, FieldElement>,
+        fixed_cols: HashMap<&'a str, &'a Vec<FieldElement>>,
         witness_cols: &'a Vec<WitnessColumn<'a>>,
         witness_ids: HashMap<&'a str, usize>,
     ) -> Self {

--- a/src/witness_generator/symbolic_evaluator.rs
+++ b/src/witness_generator/symbolic_evaluator.rs
@@ -72,7 +72,7 @@ impl<'a> SymbolicEvaluator<'a> {
 
 impl<'a> SymbolicVariables for SymbolicEvaluator<'a> {
     fn constant(&self, name: &str) -> Result<AffineExpression, EvalError> {
-        Ok(self.fixed_data.constants[name].clone().into())
+        Ok(self.fixed_data.constants[name].into())
     }
 
     fn value(&self, name: &str, next: bool) -> Result<AffineExpression, EvalError> {

--- a/src/witness_generator/symbolic_witness_evaluator.rs
+++ b/src/witness_generator/symbolic_witness_evaluator.rs
@@ -42,7 +42,7 @@ where
     WA: WitnessColumnEvaluator + WitnessColumnNamer,
 {
     fn constant(&self, name: &str) -> Result<AffineExpression, EvalError> {
-        Ok(self.fixed_data.constants[name].clone().into())
+        Ok(self.fixed_data.constants[name].into())
     }
 
     fn value(&self, name: &str, next: bool) -> Result<AffineExpression, EvalError> {
@@ -62,7 +62,7 @@ where
             } else {
                 self.row
             };
-            Ok(values[row as usize].clone().into())
+            Ok(values[row as usize].into())
         }
     }
 

--- a/tests/asm.rs
+++ b/tests/asm.rs
@@ -1,10 +1,10 @@
 use common::verify_asm_string;
-use powdr::number::AbstractNumberType;
+use powdr::number::FieldElement;
 use std::fs;
 
 mod common;
 
-fn verify_asm(file_name: &str, inputs: Vec<AbstractNumberType>) {
+fn verify_asm(file_name: &str, inputs: Vec<FieldElement>) {
     let contents = fs::read_to_string(format!("./tests/asm_data/{file_name}")).unwrap();
     verify_asm_string(file_name, &contents, inputs)
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -2,10 +2,10 @@ use std::{fs, path::Path, process::Command};
 
 use itertools::Itertools;
 use powdr::compiler;
-use powdr::number::AbstractNumberType;
+use powdr::number::FieldElement;
 
 #[allow(unused)]
-pub fn verify_asm_string(file_name: &str, contents: &str, inputs: Vec<AbstractNumberType>) {
+pub fn verify_asm_string(file_name: &str, contents: &str, inputs: Vec<FieldElement>) {
     let pil = powdr::asm_compiler::compile(Some(file_name), contents).unwrap();
     let pil_file_name = "asm.pil";
     let temp_dir = mktemp::Temp::new_dir().unwrap();

--- a/tests/pil.rs
+++ b/tests/pil.rs
@@ -1,13 +1,13 @@
 use std::path::Path;
 
 use powdr::compiler;
-use powdr::number::AbstractNumberType;
+use powdr::number::FieldElement;
 
 use crate::common::verify;
 
 mod common;
 
-pub fn verify_pil(file_name: &str, query_callback: Option<fn(&str) -> Option<AbstractNumberType>>) {
+pub fn verify_pil(file_name: &str, query_callback: Option<fn(&str) -> Option<FieldElement>>) {
     let input_file = Path::new(&format!("./tests/pil_data/{file_name}"))
         .canonicalize()
         .unwrap();

--- a/tests/riscv.rs
+++ b/tests/riscv.rs
@@ -1,5 +1,5 @@
 use common::verify_asm_string;
-use powdr::number::AbstractNumberType;
+use powdr::number::FieldElement;
 
 mod common;
 
@@ -52,14 +52,14 @@ fn test_keccak() {
     verify_crate(case, vec![]);
 }
 
-fn verify_file(case: &str, inputs: Vec<AbstractNumberType>) {
+fn verify_file(case: &str, inputs: Vec<FieldElement>) {
     let riscv_asm = powdr::riscv::compile_rust_to_riscv_asm(&format!("tests/riscv_data/{case}"));
     let powdr_asm = powdr::riscv::compiler::compile_riscv_asm(&riscv_asm);
 
     verify_asm_string(&format!("{case}.asm"), &powdr_asm, inputs);
 }
 
-fn verify_crate(case: &str, inputs: Vec<AbstractNumberType>) {
+fn verify_crate(case: &str, inputs: Vec<FieldElement>) {
     let riscv_asm = powdr::riscv::compile_rust_crate_to_riscv_asm(&format!(
         "tests/riscv_data/{case}/Cargo.toml"
     ));


### PR DESCRIPTION
Using field division everywhere except for computation of constants.

Todo:
- [x] Which generator to use for Goldilocks? 7 like in [plonky2](https://github.com/mir-protocol/plonky2/blob/049a258b4a877c7df2ce3b028a79bedfff8bd6da/field/src/goldilocks_field.rs#L80)
- [x] `to_degree` is used a lot now as u64 is used for both row numbering and the integer type. I was thinking of introducing `to_integer` which right now does the same but would provide some clarity?