### PR TITLE
Restrict pc

### DIFF
--- a/compiler/tests/asm.rs
+++ b/compiler/tests/asm.rs
@@ -47,6 +47,6 @@ fn functional_instructions() {
 }
 
 #[test]
-fn full_pil_column() {
+fn full_pil_constant() {
     verify_asm("full_pil_constant.asm", Default::default());
 }

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -118,11 +118,25 @@ impl ArrayExpression {
         Self::Concat(Box::new(self), Box::new(other))
     }
 
+    fn pad_with(self, pad: Expression) -> Self {
+        Self::concat(self, Self::repeated_value(vec![pad]))
+    }
+
     pub fn pad_with_zeroes(self) -> Self {
-        Self::concat(
-            self,
-            Self::repeated_value(vec![Expression::Number(0.into())]),
-        )
+        self.pad_with(Expression::Number(0.into()))
+    }
+
+    fn last(&self) -> Option<&Expression> {
+        match self {
+            ArrayExpression::Value(v) => v.last(),
+            ArrayExpression::RepeatedValue(v) => v.last(),
+            ArrayExpression::Concat(_, right) => right.last(),
+        }
+    }
+
+    // return None if `self` is empty
+    pub fn pad_with_last(self) -> Option<Self> {
+        self.last().cloned().map(|last| self.pad_with(last))
     }
 }
 

--- a/test_data/asm/bit_access.asm
+++ b/test_data/asm/bit_access.asm
@@ -15,6 +15,7 @@ pil{
 // Wraps a value in Y to 32 bits.
 // Requires 0 <= Y < 2**33
 instr wrap Y -> X { Y = X + wrap_bit * 2**32, X = XB1 + 0x100 * XB2 + 0x10000 * XB3 + 0x1000000 * XB4 }
+instr loop { pc' = pc }
 pil{
     col fixed BYTE(i) { i & 0xff };
     col witness XB1;
@@ -34,3 +35,4 @@ instr assert_zero X { XIsZero = 1 }
 B <=X= ${ ("input", 0) };
 wrap B + 0xffffffec, A;
 assert_zero A;
+loop;

--- a/test_data/asm/functional_instructions.asm
+++ b/test_data/asm/functional_instructions.asm
@@ -31,7 +31,9 @@ pil{
 }
 
 instr assert_zero X { XIsZero = 1 }
+instr loop { pc' = pc }
 
 B <=X= ${ ("input", 0) };
 A <=X= wrap(B + 0xffffffec);
 assert_zero A;
+loop;

--- a/test_data/asm/mem_read_write.asm
+++ b/test_data/asm/mem_read_write.asm
@@ -63,6 +63,7 @@ pil{
 instr assert_zero X { XIsZero = 1 }
 instr mstore X { { ADDR, STEP, X } is m_is_write { m_addr, m_step, m_value } }
 instr mload -> X { { ADDR, STEP, X } is m_is_read { m_addr, m_step, m_value } }
+instr loop { pc' = pc }
 
 
 ADDR <=X= 4;
@@ -74,3 +75,4 @@ assert_zero A - 4;
 ADDR <=X= 4;
 mload A;
 assert_zero A - 1;
+loop;

--- a/test_data/asm/multi_assign.asm
+++ b/test_data/asm/multi_assign.asm
@@ -12,7 +12,9 @@ pil{
 }
 
 instr assert_zero X { XIsZero = 1 }
+instr loop { pc' = pc }
 
 A <=X= ${ ("input", 0) };
 A <=Y= A - 7;
 assert_zero A;
+loop;

--- a/test_data/asm/palindrome.asm
+++ b/test_data/asm/palindrome.asm
@@ -67,3 +67,4 @@ check::
  jmp check;
 
 end::
+ jmp end;

--- a/test_data/asm/simple_sum.asm
+++ b/test_data/asm/simple_sum.asm
@@ -39,10 +39,12 @@ start::
  dec_CNT;
  jmp start;
 
-end::
+check::
  A <=X= A - ${ ("input", 0) };
  assert_zero A;
 
+end::
+ jmp end;
  
 /// -------------------------- compiled into the following pil file -------------------------------
 


### PR DESCRIPTION
Currently the pc can increase beyond the program pc. Force it to stay within bounds with an explicit infinite loop in asm.
This reduces the program lookup index.