### PR TITLE
Use BTreeMap for AffineExpression.

### DIFF
--- a/executor/src/witgen/affine_expression.rs
+++ b/executor/src/witgen/affine_expression.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use number::AbstractNumberType;
 // TODO this should probably rather be a finite field element.
 use number::FieldElement;
@@ -12,14 +14,14 @@ use super::EvalResult;
 /// An expression affine in the committed polynomials.
 #[derive(Debug, Clone)]
 pub struct AffineExpression {
-    pub coefficients: Vec<FieldElement>,
+    pub coefficients: BTreeMap<usize, FieldElement>,
     pub offset: FieldElement,
 }
 
 impl From<FieldElement> for AffineExpression {
     fn from(value: FieldElement) -> Self {
         AffineExpression {
-            coefficients: Vec::new(),
+            coefficients: Default::default(),
             offset: value,
         }
     }
@@ -28,7 +30,7 @@ impl From<FieldElement> for AffineExpression {
 impl From<u32> for AffineExpression {
     fn from(value: u32) -> Self {
         AffineExpression {
-            coefficients: Vec::new(),
+            coefficients: Default::default(),
             offset: value.into(),
         }
     }
@@ -37,7 +39,7 @@ impl From<u32> for AffineExpression {
 impl AffineExpression {
     pub fn from_witness_poly_value(poly_id: usize) -> AffineExpression {
         AffineExpression {
-            coefficients: [vec![0.into(); poly_id], vec![1.into()]].concat(),
+            coefficients: BTreeMap::from([(poly_id, 1.into())]),
             offset: 0.into(),
         }
     }
@@ -62,12 +64,11 @@ impl AffineExpression {
     pub fn nonzero_coefficients(&self) -> impl Iterator<Item = (usize, &FieldElement)> {
         self.coefficients
             .iter()
-            .enumerate()
-            .filter(|(_, c)| !c.is_zero())
+            .filter_map(|(i, c)| (!c.is_zero()).then_some((*i, c)))
     }
 
     pub fn mul(mut self, factor: FieldElement) -> AffineExpression {
-        for f in &mut self.coefficients {
+        for f in self.coefficients.values_mut() {
             *f = *f * factor;
         }
         self.offset = self.offset * factor;
@@ -280,11 +281,11 @@ impl std::ops::Add for AffineExpression {
 
     fn add(self, rhs: Self) -> Self::Output {
         let mut coefficients = rhs.coefficients;
-        if self.coefficients.len() > coefficients.len() {
-            coefficients.resize(self.coefficients.len(), 0.into());
-        }
-        for (i, v) in self.coefficients.iter().enumerate() {
-            coefficients[i] = coefficients[i] + v;
+        for (i, v) in self.coefficients.into_iter() {
+            coefficients
+                .entry(i)
+                .and_modify(|x| *x += v)
+                .or_insert_with(|| v);
         }
         AffineExpression {
             coefficients,
@@ -297,7 +298,7 @@ impl std::ops::Neg for AffineExpression {
     type Output = AffineExpression;
 
     fn neg(mut self) -> Self::Output {
-        self.coefficients.iter_mut().for_each(|v| *v = -*v);
+        self.coefficients.values_mut().for_each(|v| *v = -*v);
         self.offset = -self.offset;
         self
     }
@@ -319,8 +320,11 @@ mod test {
     use crate::witgen::{bit_constraints::BitConstraint, eval_error::EvalError};
     use number::FieldElement;
 
-    fn convert(input: Vec<i32>) -> Vec<FieldElement> {
-        input.into_iter().map(|x| x.into()).collect()
+    fn convert<T>(input: Vec<T>) -> BTreeMap<usize, FieldElement>
+    where
+        T: Into<FieldElement> + Copy,
+    {
+        input.iter().map(|x| (*x).into()).enumerate().collect()
     }
 
     #[test]
@@ -332,11 +336,11 @@ mod test {
         assert_eq!(
             -a,
             AffineExpression {
-                coefficients: vec![
+                coefficients: convert(vec![
                     FieldElement::from(0) - FieldElement::from(1u64),
                     0.into(),
                     FieldElement::from(0) - FieldElement::from(2u64),
-                ],
+                ]),
                 offset: FieldElement::from(0) - FieldElement::from(9u64),
             },
         );


### PR DESCRIPTION
This makes the loop a little slower:
From 8.2k rows/sec to 7.7k rows/sec

But the regular computations roughly double in speed:
From 430 to 820 rows/sec