### PR TITLE
implement the srai instruction

### DIFF
--- a/riscv/src/compiler.rs
+++ b/riscv/src/compiler.rs
@@ -787,6 +787,27 @@ fn process_instruction(instr: &str, args: &[Argument]) -> Vec<String> {
                 rd,
             )
         }
+        "srai" => {
+            // arithmetic shift right
+            // TODO see if we can implement this directly with a machine.
+            // Now we are using the equivalence
+            // a >>> b = (a >= 0 ? a >> b : ~(~a >> b))
+            let (rd, rs, amount) = rri(args);
+            assert!(amount <= 31);
+            only_if_no_write_to_zero_vec(
+                vec![
+                    format!("tmp1 <=X= to_signed({rs});"),
+                    format!("tmp1 <=Y= is_positive(0 - tmp1);"),
+                    format!("tmp1 <=X= tmp1 * 0xffffffff;"),
+                    // Here, tmp1 is the full bit mask if rs is negative
+                    // and zero otherwise.
+                    format!("{rd} <=X= xor(tmp1, {rs});"),
+                    format!("{rd} <=X= shr({rd}, {amount});"),
+                    format!("{rd} <=X= xor(tmp1, {rd});"),
+                ],
+                rd,
+            )
+        }
 
         // comparison
         "seqz" => {

--- a/riscv/src/reachability.rs
+++ b/riscv/src/reachability.rs
@@ -168,10 +168,10 @@ fn ends_control_flow(s: &Statement) -> bool {
         Statement::Instruction(instruction, _) => match instruction.as_str() {
             "li" | "lui" | "mv" | "add" | "addi" | "sub" | "neg" | "mul" | "mulhu" | "xor"
             | "xori" | "and" | "andi" | "or" | "ori" | "not" | "slli" | "sll" | "srli" | "srl"
-            | "seqz" | "snez" | "slti" | "sltu" | "sltiu" | "beq" | "beqz" | "bgeu" | "bltu"
-            | "blt" | "bge" | "bltz" | "blez" | "bgtz" | "bgez" | "bne" | "bnez" | "jal"
-            | "jalr" | "call" | "ecall" | "ebreak" | "lw" | "lb" | "lbu" | "sw" | "sh" | "sb"
-            | "nop" => false,
+            | "srai" | "seqz" | "snez" | "slti" | "sltu" | "sltiu" | "beq" | "beqz" | "bgeu"
+            | "bltu" | "blt" | "bge" | "bltz" | "blez" | "bgtz" | "bgez" | "bne" | "bnez"
+            | "jal" | "jalr" | "call" | "ecall" | "ebreak" | "lw" | "lb" | "lbu" | "sw" | "sh"
+            | "sb" | "nop" => false,
             "j" | "jr" | "tail" | "ret" | "unimp" => true,
             _ => {
                 panic!("Unknown instruction: {instruction}");

--- a/riscv/tests/instruction_tests/generated/srai.S
+++ b/riscv/tests/instruction_tests/generated/srai.S
@@ -1,0 +1,137 @@
+# 1 "sources/srai.S"
+# 1 "<built-in>"
+# 1 "<command-line>"
+# 31 "<command-line>"
+# 1 "/usr/include/stdc-predef.h" 1 3 4
+# 32 "<command-line>" 2
+# 1 "sources/srai.S"
+# See LICENSE for license details.
+
+#*****************************************************************************
+# srai.S
+#-----------------------------------------------------------------------------
+
+# Test srai instruction.
+
+
+# 1 "sources/riscv_test.h" 1
+# 11 "sources/srai.S" 2
+# 1 "sources/test_macros.h" 1
+
+
+
+
+
+
+#-----------------------------------------------------------------------
+# Helper macros
+#-----------------------------------------------------------------------
+# 20 "sources/test_macros.h"
+# We use a macro hack to simpify code generation for various numbers
+# of bubble cycles.
+# 36 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# RV64UI MACROS
+#-----------------------------------------------------------------------
+
+#-----------------------------------------------------------------------
+# Tests for instructions with immediate operand
+#-----------------------------------------------------------------------
+# 92 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Tests for vector config instructions
+#-----------------------------------------------------------------------
+# 120 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Tests for an instruction with register operands
+#-----------------------------------------------------------------------
+# 148 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Tests for an instruction with register-register operands
+#-----------------------------------------------------------------------
+# 242 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Test memory instructions
+#-----------------------------------------------------------------------
+# 319 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Test branch instructions
+#-----------------------------------------------------------------------
+# 404 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Test jump instructions
+#-----------------------------------------------------------------------
+# 433 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# RV64UF MACROS
+#-----------------------------------------------------------------------
+
+#-----------------------------------------------------------------------
+# Tests floating-point instructions
+#-----------------------------------------------------------------------
+# 569 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Pass and fail code (assumes test num is in x28)
+#-----------------------------------------------------------------------
+# 581 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Test data section
+#-----------------------------------------------------------------------
+# 12 "sources/srai.S" 2
+
+
+.globl __runtime_start; __runtime_start:
+
+  #-------------------------------------------------------------
+  # Arithmetic tests
+  #-------------------------------------------------------------
+
+  test_2: li x10, 2; ebreak; li x1, 0x00000000; srai x3, x1, ((0) | (-(((0) >> 11) & 1) << 11));; li x29, 0x00000000; li x28, 2; bne x3, x29, fail;;
+  test_3: li x10, 3; ebreak; li x1, 0x80000000; srai x3, x1, ((1) | (-(((1) >> 11) & 1) << 11));; li x29, 0xc0000000; li x28, 3; bne x3, x29, fail;;
+  test_4: li x10, 4; ebreak; li x1, 0x80000000; srai x3, x1, ((7) | (-(((7) >> 11) & 1) << 11));; li x29, 0xff000000; li x28, 4; bne x3, x29, fail;;
+  test_5: li x10, 5; ebreak; li x1, 0x80000000; srai x3, x1, ((14) | (-(((14) >> 11) & 1) << 11));; li x29, 0xfffe0000; li x28, 5; bne x3, x29, fail;;
+  test_6: li x10, 6; ebreak; li x1, 0x80000001; srai x3, x1, ((31) | (-(((31) >> 11) & 1) << 11));; li x29, 0xffffffff; li x28, 6; bne x3, x29, fail;;
+
+  test_7: li x10, 7; ebreak; li x1, 0x7fffffff; srai x3, x1, ((0) | (-(((0) >> 11) & 1) << 11));; li x29, 0x7fffffff; li x28, 7; bne x3, x29, fail;;
+  test_8: li x10, 8; ebreak; li x1, 0x7fffffff; srai x3, x1, ((1) | (-(((1) >> 11) & 1) << 11));; li x29, 0x3fffffff; li x28, 8; bne x3, x29, fail;;
+  test_9: li x10, 9; ebreak; li x1, 0x7fffffff; srai x3, x1, ((7) | (-(((7) >> 11) & 1) << 11));; li x29, 0x00ffffff; li x28, 9; bne x3, x29, fail;;
+  test_10: li x10, 10; ebreak; li x1, 0x7fffffff; srai x3, x1, ((14) | (-(((14) >> 11) & 1) << 11));; li x29, 0x0001ffff; li x28, 10; bne x3, x29, fail;;
+  test_11: li x10, 11; ebreak; li x1, 0x7fffffff; srai x3, x1, ((31) | (-(((31) >> 11) & 1) << 11));; li x29, 0x00000000; li x28, 11; bne x3, x29, fail;;
+
+  test_12: li x10, 12; ebreak; li x1, 0x81818181; srai x3, x1, ((0) | (-(((0) >> 11) & 1) << 11));; li x29, 0x81818181; li x28, 12; bne x3, x29, fail;;
+  test_13: li x10, 13; ebreak; li x1, 0x81818181; srai x3, x1, ((1) | (-(((1) >> 11) & 1) << 11));; li x29, 0xc0c0c0c0; li x28, 13; bne x3, x29, fail;;
+  test_14: li x10, 14; ebreak; li x1, 0x81818181; srai x3, x1, ((7) | (-(((7) >> 11) & 1) << 11));; li x29, 0xff030303; li x28, 14; bne x3, x29, fail;;
+  test_15: li x10, 15; ebreak; li x1, 0x81818181; srai x3, x1, ((14) | (-(((14) >> 11) & 1) << 11));; li x29, 0xfffe0606; li x28, 15; bne x3, x29, fail;;
+  test_16: li x10, 16; ebreak; li x1, 0x81818181; srai x3, x1, ((31) | (-(((31) >> 11) & 1) << 11));; li x29, 0xffffffff; li x28, 16; bne x3, x29, fail;;
+
+  #-------------------------------------------------------------
+  # Source/Destination tests
+  #-------------------------------------------------------------
+
+  test_17: li x10, 17; ebreak; li x1, 0x80000000; srai x1, x1, ((7) | (-(((7) >> 11) & 1) << 11));; li x29, 0xff000000; li x28, 17; bne x1, x29, fail;;
+
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  test_18: li x10, 18; ebreak; li x4, 0; test_18_l1: li x1, 0x80000000; srai x3, x1, ((7) | (-(((7) >> 11) & 1) << 11)); addi x6, x3, 0; addi x4, x4, 1; li x5, 2; bne x4, x5, test_18_l1; li x29, 0xff000000; li x28, 18; bne x6, x29, fail;;
+  test_19: li x10, 19; ebreak; li x4, 0; test_19_l1: li x1, 0x80000000; srai x3, x1, ((14) | (-(((14) >> 11) & 1) << 11)); nop; addi x6, x3, 0; addi x4, x4, 1; li x5, 2; bne x4, x5, test_19_l1; li x29, 0xfffe0000; li x28, 19; bne x6, x29, fail;;
+  test_20: li x10, 20; ebreak; li x4, 0; test_20_l1: li x1, 0x80000001; srai x3, x1, ((31) | (-(((31) >> 11) & 1) << 11)); nop; nop; addi x6, x3, 0; addi x4, x4, 1; li x5, 2; bne x4, x5, test_20_l1; li x29, 0xffffffff; li x28, 20; bne x6, x29, fail;;
+
+  test_21: li x10, 21; ebreak; li x4, 0; test_21_l1: li x1, 0x80000000; srai x3, x1, ((7) | (-(((7) >> 11) & 1) << 11)); addi x4, x4, 1; li x5, 2; bne x4, x5, test_21_l1; li x29, 0xff000000; li x28, 21; bne x3, x29, fail;;
+  test_22: li x10, 22; ebreak; li x4, 0; test_22_l1: li x1, 0x80000000; nop; srai x3, x1, ((14) | (-(((14) >> 11) & 1) << 11)); addi x4, x4, 1; li x5, 2; bne x4, x5, test_22_l1; li x29, 0xfffe0000; li x28, 22; bne x3, x29, fail;;
+  test_23: li x10, 23; ebreak; li x4, 0; test_23_l1: li x1, 0x80000001; nop; nop; srai x3, x1, ((31) | (-(((31) >> 11) & 1) << 11)); addi x4, x4, 1; li x5, 2; bne x4, x5, test_23_l1; li x29, 0xffffffff; li x28, 23; bne x3, x29, fail;;
+
+  test_24: li x10, 24; ebreak; srai x1, x0, ((31) | (-(((31) >> 11) & 1) << 11));; li x29, 0; li x28, 24; bne x1, x29, fail;;
+  test_25: li x10, 25; ebreak; li x1, 33; srai x0, x1, ((20) | (-(((20) >> 11) & 1) << 11));; li x29, 0; li x28, 25; bne x0, x29, fail;;
+
+  bne x0, x28, pass; fail: unimp;; pass: ___pass: j ___pass;
+
+
+
+  .data
+.balign 4;
+
+ 
+
+

--- a/riscv/tests/instruction_tests/sources/srai.S
+++ b/riscv/tests/instruction_tests/sources/srai.S
@@ -1,0 +1,68 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# srai.S
+#-----------------------------------------------------------------------------
+#
+# Test srai instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV32U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Arithmetic tests
+  #-------------------------------------------------------------
+
+  TEST_IMM_OP( 2,  srai, 0x00000000, 0x00000000, 0  );
+  TEST_IMM_OP( 3,  srai, 0xc0000000, 0x80000000, 1  );
+  TEST_IMM_OP( 4,  srai, 0xff000000, 0x80000000, 7  );
+  TEST_IMM_OP( 5,  srai, 0xfffe0000, 0x80000000, 14 );
+  TEST_IMM_OP( 6,  srai, 0xffffffff, 0x80000001, 31 );
+
+  TEST_IMM_OP( 7,  srai, 0x7fffffff, 0x7fffffff, 0  );
+  TEST_IMM_OP( 8,  srai, 0x3fffffff, 0x7fffffff, 1  );
+  TEST_IMM_OP( 9,  srai, 0x00ffffff, 0x7fffffff, 7  );
+  TEST_IMM_OP( 10, srai, 0x0001ffff, 0x7fffffff, 14 );
+  TEST_IMM_OP( 11, srai, 0x00000000, 0x7fffffff, 31 );
+
+  TEST_IMM_OP( 12, srai, 0x81818181, 0x81818181, 0  );
+  TEST_IMM_OP( 13, srai, 0xc0c0c0c0, 0x81818181, 1  );
+  TEST_IMM_OP( 14, srai, 0xff030303, 0x81818181, 7  );
+  TEST_IMM_OP( 15, srai, 0xfffe0606, 0x81818181, 14 );
+  TEST_IMM_OP( 16, srai, 0xffffffff, 0x81818181, 31 );
+
+  #-------------------------------------------------------------
+  # Source/Destination tests
+  #-------------------------------------------------------------
+
+  TEST_IMM_SRC1_EQ_DEST( 17, srai, 0xff000000, 0x80000000, 7 );
+
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  TEST_IMM_DEST_BYPASS( 18, 0, srai, 0xff000000, 0x80000000, 7  );
+  TEST_IMM_DEST_BYPASS( 19, 1, srai, 0xfffe0000, 0x80000000, 14 );
+  TEST_IMM_DEST_BYPASS( 20, 2, srai, 0xffffffff, 0x80000001, 31 );
+
+  TEST_IMM_SRC1_BYPASS( 21, 0, srai, 0xff000000, 0x80000000, 7 );
+  TEST_IMM_SRC1_BYPASS( 22, 1, srai, 0xfffe0000, 0x80000000, 14 );
+  TEST_IMM_SRC1_BYPASS( 23, 2, srai, 0xffffffff, 0x80000001, 31 );
+
+  TEST_IMM_ZEROSRC1( 24, srai, 0, 31 );
+  TEST_IMM_ZERODEST( 25, srai, 33, 20 );
+#
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/riscv/tests/riscv_data/memfuncs/src/lib.rs
+++ b/riscv/tests/riscv_data/memfuncs/src/lib.rs
@@ -54,20 +54,18 @@ pub fn main() {
     }
 
     // Check memcmp accross boundaries
-    // This doesn't work because it compiles to the unsupported
-    // assembly instruction "srai".
-    // unsafe {
-    //     assert_eq!(
-    //         __runtime_memcmp(output.as_ptr().offset(5), input.as_ptr().offset(5), 32),
-    //         0,
-    //     );
-    //     assert_eq!(
-    //         __runtime_memcmp(output.as_ptr().offset(5), input.as_ptr().offset(6), 32),
-    //         -1,
-    //     );
-    //     assert_eq!(
-    //         __runtime_memcmp(output.as_ptr().offset(6), input.as_ptr().offset(5), 32),
-    //         1,
-    //     );
-    // }
+    unsafe {
+        assert_eq!(
+            __runtime_memcmp(output.as_ptr().offset(5), input.as_ptr().offset(5), 32),
+            0,
+        );
+        assert_eq!(
+            __runtime_memcmp(output.as_ptr().offset(6), input.as_ptr().offset(5), 32),
+            -1,
+        );
+        assert_eq!(
+            __runtime_memcmp(input.as_ptr().offset(5), output.as_ptr().offset(6), 32),
+            1,
+        );
+    }
 }


### PR DESCRIPTION
In order to activate the memcmp tests, `srai` needs to be implemented. It's implemented in powdr assembly, and not as a powdr instruction. Still in draft, as it needs more testing, but I am sharing it to ensure that this is the favored approach.