### PR TITLE
Fixed bug where output dir had to be absolute.

### DIFF
--- a/compiler/src/verify.rs
+++ b/compiler/src/verify.rs
@@ -19,7 +19,7 @@ pub fn compile_asm_string_temp(
     let temp_dir = mktemp::Temp::new_dir().unwrap();
     assert!(crate::compile_pil_ast(
         &pil,
-        pil_file_name,
+        pil_file_name.as_ref(),
         &temp_dir,
         Some(|query: &str| {
             let items = query.split(',').map(|s| s.trim()).collect::<Vec<_>>();


### PR DESCRIPTION
If a relative output dir was used, it was concatenated twice in the json output path, causing a panic because path didn't exists.

This fixes it.