### PR TITLE
fix riscv print test

### DIFF
--- a/riscv/tests/riscv.rs
+++ b/riscv/tests/riscv.rs
@@ -69,8 +69,8 @@ fn test_keccak() {
 // TODO: instead of just checking for panic, we could check the stdout for the actual message.
 #[should_panic]
 fn test_print() {
-    let case = "print";
-    verify_crate(case, vec![]);
+    let case = "print.rs";
+    verify_file(case, vec![]);
 }
 
 fn verify_file(case: &str, inputs: Vec<GoldilocksField>) {


### PR DESCRIPTION
Currently this is panicking at

```
running 1 test
error: manifest path `tests/riscv_data/print/Cargo.toml` does not exist
thread 'test_print' panicked at 'assertion failed: cargo_status.success()', riscv/src/lib.rs:187:5
```

Now it panics at
```
thread 'test_print' panicked at 'Unknown instruction: srai', riscv/src/reachability.rs:177:17
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
which I guess is not the intended behavior?
